### PR TITLE
Update to be compatible with Julia v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,4 @@
+name = "ConcreteAbstractions"
+uuid = "3211512c-c066-11e9-2aef-ffbb4619acb5"
+authors = ["kennethberry <rosskberry@gmail.com>"]
+version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ using ConcreteAbstractions
 The abstract definition:
 
 ```julia
-@base type AbstractFoo{T}
+@base struct AbstractFoo{T}
     a
     b::Int
     c::T
@@ -27,14 +27,14 @@ end
 is really more like:
 
 ```julia
-abstract AbstractFoo
+abstract type AbstractFoo end
 ConcreteAbstractions._base_types[:AbstractFoo] = ([:T], :(begin; a; b::Int; c::T; d::Vector{T}; end))
 ```
 
 and the child definition:
 
 ```julia
-@extend type Foo <: AbstractFoo
+@extend struct Foo <: AbstractFoo
     e::T
 end
 ```
@@ -42,7 +42,7 @@ end
 is really more like:
 
 ```julia
-type Foo{T} <: AbstractFoo
+struct Foo{T} <: AbstractFoo
     a
     b::Int
     c::T

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.5-
+julia 1.0-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using ConcreteAbstractions
-using Base.Test
+using Test
 
 @base struct AbstractFoo{T}
     a
@@ -14,10 +14,9 @@ end
 
 @testset begin
     @test Foo <: AbstractFoo
-
     foo = Foo(10,10,10,[10],5)
     @test isa(foo, Foo{Int})
-    @test fieldnames(foo) == [:a,:b,:c,:d,:e]
+    @test fieldnames(typeof(foo)) == (:a,:b,:c,:d,:e)
     @test isa(foo.a, Int)
     @test isa(foo.b, Int)
     @test isa(foo.c, Int)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,14 @@
 using ConcreteAbstractions
 using Base.Test
 
-@base type AbstractFoo{T}
+@base struct AbstractFoo{T}
     a
     b::Int
     c::T
     d::Vector{T}
 end
 
-@extend type Foo <: AbstractFoo
+@extend struct Foo <: AbstractFoo
     e::T
 end
 


### PR DESCRIPTION
Change all occurrences of the keywords **type** and **abstract** to **struct** and **abstract type** respectively.  

Update runtests.jl to import from Test instead of Base.Test and change correct fieldnames to check against to be contained in a Tuple instead of an Array.